### PR TITLE
Automated voice chat via n8n dialogue

### DIFF
--- a/components/logic/useVoiceChat.ts
+++ b/components/logic/useVoiceChat.ts
@@ -1,6 +1,19 @@
-import { useCallback } from "react";
+import {
+  StreamingEvents,
+  TaskMode,
+  TaskType,
+} from "@heygen/streaming-avatar";
+import { useCallback, useRef } from "react";
 
 import { useStreamingAvatarContext } from "./context";
+
+async function fetchN8NDialogue() {
+  const res = await fetch("/api/get-n8n-dialogue");
+  if (!res.ok) {
+    throw new Error("Failed to load dialogue");
+  }
+  return await res.json();
+}
 
 export const useVoiceChat = () => {
   const {
@@ -13,26 +26,77 @@ export const useVoiceChat = () => {
     setIsVoiceChatLoading,
   } = useStreamingAvatarContext();
 
+  const dialogueRef = useRef<string[]>([]);
+  const dialogueIndexRef = useRef(0);
+
+  const playNextLine = useCallback(async () => {
+    const line = dialogueRef.current[dialogueIndexRef.current];
+    if (!line) return;
+    await avatarRef.current?.speak({
+      text: line,
+      taskType: TaskType.TALK,
+      taskMode: TaskMode.ASYNC,
+    });
+    dialogueIndexRef.current += 1;
+  }, [avatarRef]);
+
+  const handleUserEnd = useCallback(() => {
+    void playNextLine();
+  }, [playNextLine]);
+
   const startVoiceChat = useCallback(
     async (isInputAudioMuted?: boolean) => {
       if (!avatarRef.current) return;
       setIsVoiceChatLoading(true);
-      await avatarRef.current?.startVoiceChat({
-        isInputAudioMuted,
-      });
-      setIsVoiceChatLoading(false);
-      setIsVoiceChatActive(true);
-      setIsMuted(!!isInputAudioMuted);
+
+      try {
+        const data = await fetchN8NDialogue();
+        if (Array.isArray(data.dialogue)) {
+          dialogueRef.current = data.dialogue;
+        } else if (data.script) {
+          dialogueRef.current = data.script
+            .split("\n")
+            .map((l: string) => l.trim())
+            .filter(Boolean);
+        } else {
+          dialogueRef.current = [];
+        }
+        dialogueIndexRef.current = 0;
+
+        avatarRef.current.on(StreamingEvents.USER_END_MESSAGE, handleUserEnd);
+        avatarRef.current.startListening();
+        if (isInputAudioMuted) {
+          avatarRef.current.muteInputAudio();
+        } else {
+          avatarRef.current.unmuteInputAudio();
+        }
+
+        await playNextLine();
+        setIsVoiceChatActive(true);
+        setIsMuted(!!isInputAudioMuted);
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setIsVoiceChatLoading(false);
+      }
     },
-    [avatarRef, setIsMuted, setIsVoiceChatActive, setIsVoiceChatLoading],
+    [
+      avatarRef,
+      handleUserEnd,
+      playNextLine,
+      setIsMuted,
+      setIsVoiceChatActive,
+      setIsVoiceChatLoading,
+    ],
   );
 
   const stopVoiceChat = useCallback(() => {
     if (!avatarRef.current) return;
-    avatarRef.current?.closeVoiceChat();
+    avatarRef.current.off(StreamingEvents.USER_END_MESSAGE, handleUserEnd);
+    avatarRef.current.stopListening();
     setIsVoiceChatActive(false);
     setIsMuted(true);
-  }, [avatarRef, setIsMuted, setIsVoiceChatActive]);
+  }, [avatarRef, handleUserEnd, setIsMuted, setIsVoiceChatActive]);
 
   const muteInputAudio = useCallback(() => {
     if (!avatarRef.current) return;


### PR DESCRIPTION
## Summary
- modify `useVoiceChat` to fetch dialogue from n8n
- automatically speak dialogue lines during voice chat

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6883dcfa2c1483229822e66b1775ff9e