### PR TITLE
Integrate n8n webhook for custom avatar dialogs

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
-HEYGEN_API_KEY=https://TU_INSTANCIA_N8N/webhook/avatar-chat
+HEYGEN_API_KEY=
 NEXT_PUBLIC_BASE_API_URL=https://api.heygen.com
+NEXT_PUBLIC_N8N_WEBHOOK_URL=

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Feel free to play around with the existing code and please leave any feedback fo
 
 4. Enter your HeyGen Enterprise API Token in the `.env` file. Replace `HEYGEN_API_KEY` with your API key. This will allow the Client app to generate secure Access Tokens with which to create interactive sessions.
 
-   You can retrieve either the API Key by logging in to HeyGen and navigating to this page in your settings: [https://app.heygen.com/settings?from=&nav=Subscriptions%20%26%20API]. 
+   You can retrieve either the API Key by logging in to HeyGen and navigating to this page in your settings: [https://app.heygen.com/settings?from=&nav=Subscriptions%20%26%20API].
 
-5. (Optional) If you would like to use the OpenAI features, enter your OpenAI Api Key in the `.env` file.
+5. (Opcional) Si deseas que los diálogos del avatar provengan de un flujo de n8n, agrega la URL de tu webhook en `NEXT_PUBLIC_N8N_WEBHOOK_URL` dentro del archivo `.env`.
 
-6. Run `npm run dev`
+6. (Optional) If you would like to use the OpenAI features, enter your OpenAI Api Key in the `.env` file.
+
+7. Run `npm run dev`
 
 ### Starting sessions
 

--- a/app/lib/n8n.ts
+++ b/app/lib/n8n.ts
@@ -1,0 +1,14 @@
+export async function fetchN8nReply(message: string): Promise<string> {
+  const url = process.env.NEXT_PUBLIC_N8N_WEBHOOK_URL;
+  if (!url) {
+    throw new Error("NEXT_PUBLIC_N8N_WEBHOOK_URL is not defined");
+  }
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message }),
+  });
+  const data = await res.json();
+  if (typeof data === "string") return data;
+  return data.reply || data.message || "";
+}


### PR DESCRIPTION
## Summary
- document new env var `NEXT_PUBLIC_N8N_WEBHOOK_URL`
- add helper to call n8n webhook
- intercept voice chat events to fetch dialog from n8n and interrupt default HeyGen reply
- add placeholder webhook variable to `.env`

## Testing
- `npm run lint` *(fails: cannot resolve `@typescript-eslint/eslint-plugin`)*

------
https://chatgpt.com/codex/tasks/task_b_68890f1d525c832285b9201f5ff989d5